### PR TITLE
fix: corriger l'espacement des options température et fréquence

### DIFF
--- a/UI_ChausseeNeuve/ViewModels/MaterialViewModels.cs
+++ b/UI_ChausseeNeuve/ViewModels/MaterialViewModels.cs
@@ -64,8 +64,8 @@ namespace UI_ChausseeNeuve.ViewModels
             get => _selectedFrequence;
             set { _selectedFrequence = value; OnPropertyChanged(); }
         }
-        public int[] TemperatureOptions { get; } = new int[] { -10, 0, 10, 15, 20, 30, 40 };
-        public int[] FrequenceOptions { get; } = new int[] { 5, 10, 15, 20 };
+        public int[] TemperatureOptions { get; } = new int[] { -10, -9, -8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40 };
+        public int[] FrequenceOptions { get; } = new int[] { 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 };
 
         protected MaterialViewModelBase()
         {


### PR DESCRIPTION
- Modifier TemperatureOptions pour espacement de 1°C : -10 à 40 avec pas de 1
- Modifier FrequenceOptions pour espacement de 1 Hz : 5 à 20 avec pas de 1
- Résoudre le problème où les boutons changeaient de 5 degrés au lieu de 1
- Maintenir les valeurs par défaut (15°C et 10 Hz) dans les nouvelles listes